### PR TITLE
feat: support localnet

### DIFF
--- a/circuits/one/client/verify.ts
+++ b/circuits/one/client/verify.ts
@@ -13,6 +13,10 @@ import {
 
 const RPC_URL = process.env.RPC_URL || "https://api.devnet.solana.com";
 
+const WS_URL =
+  process.env.WS_URL ||
+  RPC_URL.replace("https://", "wss://").replace("http://", "ws://");
+
 // NOTE: This is a devnet example program ID. For production, deploy your own
 // verifier via `sunspot deploy` and set PROGRAM_ID environment variable.
 const PROGRAM_ID =
@@ -64,6 +68,7 @@ async function main() {
 
     const sig = await verifyOnChain(instructionData, {
       rpcUrl: RPC_URL,
+      wsUrl: WS_URL,
       programId: address(PROGRAM_ID),
       walletPath,
     });

--- a/circuits/smt_exclusion/client/test-transfer.ts
+++ b/circuits/smt_exclusion/client/test-transfer.ts
@@ -60,6 +60,10 @@ import {
 
 const RPC_URL = process.env.RPC_URL || "https://api.devnet.solana.com";
 
+const WS_URL =
+  process.env.WS_URL ||
+  RPC_URL.replace("https://", "wss://").replace("http://", "ws://");
+
 const ZK_VERIFIER_PROGRAM_ID = address(
   process.env.ZK_VERIFIER_PROGRAM_ID ||
     "548u4SFWZMaRWZQqdyAgm66z7VRYtNHHF2sr7JTBXbwN"
@@ -121,11 +125,9 @@ interface RpcContext {
   sendAndConfirm: ReturnType<typeof sendAndConfirmTransactionFactory>;
 }
 
-function createRpcContext(rpcUrl: string): RpcContext {
+function createRpcContext(rpcUrl: string, wsUrl: string): RpcContext {
   const rpc = createSolanaRpc(rpcUrl);
-  const rpcSubscriptions = createSolanaRpcSubscriptions(
-    rpcUrl.replace("https://", "wss://").replace("http://", "ws://")
-  );
+  const rpcSubscriptions = createSolanaRpcSubscriptions(wsUrl);
   const sendAndConfirm = sendAndConfirmTransactionFactory({
     rpc,
     rpcSubscriptions,
@@ -294,7 +296,7 @@ async function main() {
 
   await initPoseidon();
 
-  const ctx = createRpcContext(RPC_URL);
+  const ctx = createRpcContext(RPC_URL, WS_URL);
   console.log(`RPC: ${RPC_URL}`);
   console.log(`ZK Verifier: ${ZK_VERIFIER_PROGRAM_ID}`);
   console.log(`Exclusion Program: ${EXCLUSION_PROGRAM_ID}\n`);

--- a/circuits/smt_exclusion/client/verify.ts
+++ b/circuits/smt_exclusion/client/verify.ts
@@ -22,6 +22,10 @@ import {
 
 const RPC_URL = process.env.RPC_URL || "https://api.devnet.solana.com";
 
+const WS_URL =
+  process.env.WS_URL ||
+  RPC_URL.replace("https://", "wss://").replace("http://", "ws://");
+
 // NOTE: This is a devnet example program ID. For production, deploy your own
 // verifier via `sunspot deploy` and set PROGRAM_ID environment variable.
 const PROGRAM_ID =
@@ -108,6 +112,7 @@ async function main() {
 
     const sig = await verifyOnChain(instructionData, {
       rpcUrl: RPC_URL,
+      wsUrl: WS_URL,
       programId,
       walletPath,
     });

--- a/circuits/verify_signer/client/verify.ts
+++ b/circuits/verify_signer/client/verify.ts
@@ -17,6 +17,10 @@ import {
 
 const RPC_URL = process.env.RPC_URL || "https://api.devnet.solana.com";
 
+const WS_URL =
+  process.env.WS_URL ||
+  RPC_URL.replace("https://", "wss://").replace("http://", "ws://");
+
 // NOTE: This is a devnet example program ID. For production, deploy your own
 // verifier via `sunspot deploy` and set PROGRAM_ID environment variable.
 const PROGRAM_ID =
@@ -102,6 +106,7 @@ async function main() {
 
     const sig = await verifyOnChain(instructionData, {
       rpcUrl: RPC_URL,
+      wsUrl: WS_URL,
       programId,
       walletPath,
     });

--- a/lib/verify.ts
+++ b/lib/verify.ts
@@ -19,6 +19,7 @@ import fs from "fs";
 
 export interface VerifyConfig {
   rpcUrl: string;
+  wsUrl: string;
   programId: Address;
   walletPath: string;
   computeUnits?: number;
@@ -41,9 +42,7 @@ export async function verifyOnChain(
   console.log(`Program: ${config.programId}`);
 
   const rpc = createSolanaRpc(config.rpcUrl);
-  const rpcSubscriptions = createSolanaRpcSubscriptions(
-    config.rpcUrl.replace("https://", "wss://").replace("http://", "ws://")
-  );
+  const rpcSubscriptions = createSolanaRpcSubscriptions(config.wsUrl);
   console.log(`RPC: ${config.rpcUrl}\n`);
 
   const balanceResult = await rpc.getBalance(wallet.address).send();


### PR DESCRIPTION
This change allows you to run the following commands on a localnet such as `solana-test-validator` or `surfpool`. 

Localnet uses a different port so we can't simply use a string replace.

```
RPC_URL=http://127.0.0.1:8899 WS_URL=ws://127.0.0.1:8900 just verify-all
RPC_URL=http://127.0.0.1:8899 WS_URL=ws://127.0.0.1:8900 just test-transfer-smt
```