### PR TITLE
feat: get program id from file system wallets

### DIFF
--- a/circuits/one/client/verify.ts
+++ b/circuits/one/client/verify.ts
@@ -10,6 +10,7 @@ import {
   printTransactionResult,
   handleVerifyError,
 } from "@solana-noir-examples/lib/verify";
+import { getAddressFromKeypairFile } from "@solana-noir-examples/lib/keypair";
 
 const RPC_URL = process.env.RPC_URL || "https://api.devnet.solana.com";
 
@@ -20,7 +21,8 @@ const WS_URL =
 // NOTE: This is a devnet example program ID. For production, deploy your own
 // verifier via `sunspot deploy` and set PROGRAM_ID environment variable.
 const PROGRAM_ID =
-  process.env.PROGRAM_ID || "FgcE5gSBCgcS1aDympdw5RgQLt9RBMberPqsj4JZxdeL";
+  process.env.PROGRAM_ID ||
+  (await getAddressFromKeypairFile("../target/one-keypair.json"));
 
 const circuitConfig: CircuitConfig = {
   circuitDir: path.join(process.cwd(), ".."),

--- a/circuits/smt_exclusion/client/test-transfer.ts
+++ b/circuits/smt_exclusion/client/test-transfer.ts
@@ -53,6 +53,7 @@ import {
   fieldToHex,
   initPoseidon,
 } from "./smt.js";
+import { getAddressFromKeypairFile } from "@solana-noir-examples/lib/keypair";
 
 // ============================================================================
 // Configuration
@@ -66,12 +67,14 @@ const WS_URL =
 
 const ZK_VERIFIER_PROGRAM_ID = address(
   process.env.ZK_VERIFIER_PROGRAM_ID ||
-    "548u4SFWZMaRWZQqdyAgm66z7VRYtNHHF2sr7JTBXbwN"
+    (await getAddressFromKeypairFile("../target/smt_exclusion-keypair.json"))
 );
 
 const EXCLUSION_PROGRAM_ID = address(
   process.env.EXCLUSION_PROGRAM_ID ||
-    "4WvvKAwJ2hYRqaceZyyS3s51V68LbfGsXWut7gsGnqaZ"
+    (await getAddressFromKeypairFile(
+      "../on_chain_program/target/deploy/exclusion_program_example-keypair.json"
+    ))
 );
 
 const circuitConfig: CircuitConfig = {

--- a/circuits/smt_exclusion/client/verify.ts
+++ b/circuits/smt_exclusion/client/verify.ts
@@ -19,6 +19,7 @@ import {
   printTransactionResult,
   handleVerifyError,
 } from "@solana-noir-examples/lib/verify";
+import { getAddressFromKeypairFile } from "@solana-noir-examples/lib/keypair";
 
 const RPC_URL = process.env.RPC_URL || "https://api.devnet.solana.com";
 
@@ -29,7 +30,8 @@ const WS_URL =
 // NOTE: This is a devnet example program ID. For production, deploy your own
 // verifier via `sunspot deploy` and set PROGRAM_ID environment variable.
 const PROGRAM_ID =
-  process.env.PROGRAM_ID || "548u4SFWZMaRWZQqdyAgm66z7VRYtNHHF2sr7JTBXbwN";
+  process.env.PROGRAM_ID ||
+  (await getAddressFromKeypairFile("../target/smt_exclusion-keypair.json"));
 
 const circuitConfig: CircuitConfig = {
   circuitDir: path.join(process.cwd(), ".."),

--- a/circuits/verify_signer/client/verify.ts
+++ b/circuits/verify_signer/client/verify.ts
@@ -14,6 +14,7 @@ import {
   printTransactionResult,
   handleVerifyError,
 } from "@solana-noir-examples/lib/verify";
+import { getAddressFromKeypairFile } from "@solana-noir-examples/lib/keypair";
 
 const RPC_URL = process.env.RPC_URL || "https://api.devnet.solana.com";
 
@@ -24,7 +25,8 @@ const WS_URL =
 // NOTE: This is a devnet example program ID. For production, deploy your own
 // verifier via `sunspot deploy` and set PROGRAM_ID environment variable.
 const PROGRAM_ID =
-  process.env.PROGRAM_ID || "7uatSejNcJvmp8G19F6F54uyzLkkMYnEgD58pFTTuW1A";
+  process.env.PROGRAM_ID ||
+  (await getAddressFromKeypairFile("../target/verify_signer-keypair.json"));
 
 const circuitConfig: CircuitConfig = {
   circuitDir: path.join(process.cwd(), ".."),

--- a/justfile
+++ b/justfile
@@ -103,8 +103,8 @@ prove-signer: execute-signer
     cd circuits/verify_signer && sunspot prove target/verify_signer.json target/verify_signer.gz target/verify_signer.ccs target/verify_signer.pk
 
 # Verify proof on-chain (requires deployed verifier program)
-verify-signer program_id="7uatSejNcJvmp8G19F6F54uyzLkkMYnEgD58pFTTuW1A":
-    cd circuits/verify_signer/client && pnpm run verify -- --program {{program_id}}
+verify-signer:
+    cd circuits/verify_signer/client && pnpm run verify
     git checkout circuits/verify_signer/Prover.toml 2>/dev/null || true
 
 # Full Sunspot setup (regenerates keys - only needed if circuit changes)
@@ -142,8 +142,8 @@ prove-smt: execute-smt
     cd circuits/smt_exclusion && sunspot prove target/smt_exclusion.json target/smt_exclusion.gz target/smt_exclusion.ccs target/smt_exclusion.pk
 
 # Verify proof on-chain (requires deployed verifier program)
-verify-smt program_id="548u4SFWZMaRWZQqdyAgm66z7VRYtNHHF2sr7JTBXbwN":
-    cd circuits/smt_exclusion/client && pnpm run verify -- --program {{program_id}}
+verify-smt:
+    cd circuits/smt_exclusion/client && pnpm run verify
     git checkout circuits/smt_exclusion/Prover.toml 2>/dev/null || true
 
 # Integration test: verify proof + SOL transfer (requires deployed programs)

--- a/lib/keypair.ts
+++ b/lib/keypair.ts
@@ -1,0 +1,21 @@
+import { createKeyPairSignerFromBytes, type KeyPairSigner } from "@solana/kit";
+import fs from "fs";
+import path from "path";
+
+async function loadKeypairFromFile(
+  filePath: string
+): Promise<KeyPairSigner<string>> {
+  const resolvedPath = path.resolve(filePath);
+  const loadedKeyBytes = Uint8Array.from(
+    JSON.parse(fs.readFileSync(resolvedPath, "utf8"))
+  );
+
+  return await createKeyPairSignerFromBytes(loadedKeyBytes);
+}
+
+export async function getAddressFromKeypairFile(
+  filePath: string
+): Promise<string> {
+  const keypairSigner = await loadKeypairFromFile(filePath);
+  return keypairSigner.address;
+}

--- a/lib/package.json
+++ b/lib/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "exports": {
     "./proof": "./proof.js",
-    "./verify": "./verify.js"
+    "./verify": "./verify.js",
+    "./keypair": "./keypair.js"
   },
   "scripts": {
     "build": "tsc"


### PR DESCRIPTION
This change will get the `address` from running `sunspot deploy` and `cargo build-sbf` rather than hard coding the devnet program IDs.

This makes it easier for someone to clone this repository, deploy their own examples to localnet or devnet and test with keypairs they own.

If you would prefer to keep the program IDs hard coded to devnet I would understand that preference and this can be closed.